### PR TITLE
Fix number/string comparison case & set to SPDX license.

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,5 +32,5 @@ function lt (n) { return n < 0 }
 function defaultCmp (a, b) {
   if (a < b) return -1
   else if (a > b) return 1
-  else if (a === b) return 0
+  else return 0
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "region"
   ],
   "author": "substack",
-  "license": "BSD",
+  "license": "BSD-3-Clause",
   "devDependencies": {
     "tape": "^4.4.0"
   },

--- a/test/regressions.js
+++ b/test/regressions.js
@@ -1,0 +1,11 @@
+var overlap = require('../')
+var test = require('tape')
+
+test('silent failure if string', function (t) {
+  var a1 = [ ['1','5'], ['1','5'] ]
+  var a2 = [ [1, 5], [1, 5] ]
+  var b = [ [0, 1], [0, 5] ]
+  t.equal(overlap(a1, b), true)
+  t.equal(overlap(a2, b), true)
+  t.end()
+})


### PR DESCRIPTION
When debugging `osm-p2p-db` and `kdb-tree-store` I noticed that in the case
that a `kdb.insert` is performed on `typeof v === 'string'` coordinates, the
`cmp` function in this module would fall through all `if` cases and return
`undefined`, resulting in overlap tests returning `false` that would have been
`true` otherwise. I liked this fix best because it was already working in the
case that `b` was less than or greater than `a` as it was.

Since I was already poking around, I also changed the `license` field in
`package.json` to be a specific BSD license from the [SPDX list](https://spdx.org/licenses/).